### PR TITLE
removes deprecated strict flag from phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,10 @@
 <phpunit bootstrap="tests/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
-         strict="true"
+         report-useless-tests="true"
+         strict-coverage="true"
+         disallow-test-output="true"
+         strict-global-state="true"
          colors="true"
          verbose="true">
     <testsuites>


### PR DESCRIPTION
removes deprecated strict flag from phpunit config and substitutes it with the fine grained corresponding flags (all but enforce-time-limit)
