### PR TITLE
Changed member accessibility on Binder to allow custom implementations

### DIFF
--- a/src/Binder.php
+++ b/src/Binder.php
@@ -13,11 +13,11 @@ use Doctrine\Common\Cache\FilesystemCache;
 class Binder
 {
     /** @var ValidatorInterface */
-    private $validator;
+    protected $validator;
     /** @var MapperInterface */
-    private $mapper;
+    protected $mapper;
     /** @var array */
-    private $defaultGroups;
+    protected $defaultGroups;
 
     public function __construct(ValidatorInterface $validator, MapperInterface $mapper, $addDefaultGroups = ['Default'])
     {
@@ -88,7 +88,7 @@ class Binder
         return $this->createBindResultFromFilledObject($issues, $newObject);
     }
 
-    private function createBindResultFromFilledObject($issues, $object)
+    protected function createBindResultFromFilledObject($issues, $object)
     {
         return new BindResult($object, $issues);
     }


### PR DESCRIPTION
This PR changes the accessibility of the private members on the Binder so that customizations to the bind process can happen.

We use this in our app to catch exceptions from PR #14 and pass them to our custom validator.
